### PR TITLE
Added PHP XML extension to the requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Requirements
 * PHP 5.6 or higher
 * PHP JSON extension
 * PHP LDAP extension
+* PHP XML extension
 * PHP mbstring (Multibyte String) extension
 * PHP MySQL extension
 * MySQL (5.5+), Percona Server (5.5+) or MariaDB database


### PR DESCRIPTION
PHP XML extension is also required for ssh-key-authority to work