### PR TITLE
Make sure the keys-sync service starts after MariaDB/MySQL.

### DIFF
--- a/services/systemd/keys-sync.service
+++ b/services/systemd/keys-sync.service
@@ -2,6 +2,7 @@
 Description=SSH Key synchronization daemon
 Documentation=https://github.com/operasoftware/ssh-key-authority
 Requires=mysql.service
+After=mysql.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Otherwise it will fail to start with the following error message:
`Fatal error: Uncaught DBConnectionFailedException: mysqli::__construct(): (HY000/2002): No such file or directory`